### PR TITLE
Changed regex search for temp in Slack acid clean API to account for …

### DIFF
--- a/slack/views.py
+++ b/slack/views.py
@@ -9,7 +9,7 @@ import hmac, hashlib, json, re, traceback, datetime
 from slack.models import acidclean, failed_regex_strings
 from sample_database.models import Sample, Action, Action_Type
 
-temp_re = re.compile(r'((?<= )[0-9]*)[ \t]*[C|c]?(elcius)?$') # "$" guarantees only 1 match
+temp_re = re.compile(r'([Aa][Tt][ \t]*)?((?<= )[0-9]*)[ \t]*[C|c]?(elcius)?$') # "$" guarantees only 1 match
 time_re = re.compile(r'([Aa][Tt][ \t]*)?([0-9]+):([0-9]{2})[ \t]*([AaPp][Mm])?') # (at) #(#):## (am/pm)
 
 class ParseError(Exception):


### PR DESCRIPTION
Fixed bug in parsing Slack acid-clean messages for temperature by adding variations of 'at' to regex search. 