### PR TITLE
Update Slack interface views.py to fix regex issue grabbing the temperature 

### DIFF
--- a/slack/views.py
+++ b/slack/views.py
@@ -41,7 +41,7 @@ def parseacidclean(instructions,user,fn):
             cropped_instructions = cropped_instructions[0:temp.start()].strip()
             temp = temp.groups()
             try:
-                temp = float(temp[0])
+                temp = float(temp[1])
             except:
                 raise ParseError('Failed to convert temperature "%s" to float'%temp[0])
         else:


### PR DESCRIPTION
The [at] is now stuck with the temperature. Changed index into temp.groups(), which contains groups [at] [temp], to grab the temp instead of the at. Successfully turns the temp into a float. Samples remain listed as expected.